### PR TITLE
Fix acedrg submissions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,10 @@
 FROM gcr.io/diamond-privreg/xchem/ccp4:7.1 as ccp4
+FROM gcr.io/diamond-privreg/xchem/phenix:1.20 as phenix
 
 FROM buildpack-deps:bullseye-curl as devel
 
 COPY --from=ccp4 /ccp4-7.1 /ccp4-7.1
+COPY --from=phenix /phenix-1.20 /phenix-1.20
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -19,4 +21,4 @@ RUN apt-get update \
     && pip3 install black[python2]
 
 ENV QT_X11_NO_MITSHM=1 \
-    XChemExplorer_DIR=/workspace/
+    PATH=$PATH:/ccp4-7.1/bin:/phenix-1.20/build/bin

--- a/xce/XChemExplorer.py
+++ b/xce/XChemExplorer.py
@@ -980,7 +980,6 @@ class XChemExplorer(QtGui.QApplication):
 
         if self.external_software["acedrg"]:
             program_list.append("acedrg")
-            self.restraints_program = "acedrg"
         if self.external_software["phenix.elbow"]:
             program_list.append("phenix.elbow")
         if self.external_software["grade"]:

--- a/xce/gui_scripts/settings_preferences.py
+++ b/xce/gui_scripts/settings_preferences.py
@@ -242,23 +242,24 @@ class setup:
 
         xce_object.second_cif_file = None
 
-        software_list = ["acedrg", "phenix.elbow", "grade"]
+        restraints_program_candidates = ["acedrg", "phenix.elbow", "grade"]
 
-        for software in software_list:
-            if xce_object.external_software[software]:
-                xce_object.restraints_program = str(software)
+        xce_object.restraints_program = ""
+        for restraints_program_candidate in restraints_program_candidates:
+            if restraints_program_candidate in xce_object.external_software.keys():
+                xce_object.restraints_program = restraints_program_candidate
                 xce_object.update_log.insert(
-                    "will use "
-                    + str(software)
-                    + " for generation of ligand coordinates and"
-                    " restraints"
+                    "will use {0!s} for"
+                    " generation of ligand coordinates and restraints".format(
+                        restraints_program_candidate
+                    )
                 )
-            else:
-                xce_object.restraints_program = ""
-                xce_object.update_log.warning(
-                    "No program for generation of ligand coordinates and restraints"
-                    " available!"
-                )
+                break
+        if xce_object.restraints_program is None:
+            xce_object.update_log.warning(
+                "No program for generation of ligand coordinates and restraints"
+                " available!"
+            )
 
     def preferences(self, xce_object):
         # preferences


### PR DESCRIPTION
XCE logs showed that 'failed `acedrg` cluster submissions' were actually caused by incorrectly submitted jobs which called `grade` instead of `acedrg`. The root cause of this was incorrect management of the internal and displayed state in the preferences menu